### PR TITLE
Update codeBlock.scss

### DIFF
--- a/src/layouts/codeBlock.scss
+++ b/src/layouts/codeBlock.scss
@@ -46,6 +46,7 @@
    padding: .1em .4em;
    border-radius: .3em;
    white-space: normal;
+   word-break: break-all;
  }
 
  .token.comment,


### PR DESCRIPTION
Fixes a bug in Chrome mobile where long bits of inline code would prevent overflow.